### PR TITLE
Stop depending on ZODB since we only use it for tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,11 @@ python:
     - pypy
     - pypy3
 install:
-    - pip install .
-    - pip install zope.intid[test]
+    - pip install -U pip setuptools # need updated pip for caching
+    - pip install .[test]
 script:
-    - python setup.py test -q
+    - python -m zope.intid.tests
 notifications:
     email: false
+
+cache: pip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Changes
 
 - Drop support for Python 2.6.
 
+- Stop depending on ZODB for anything except testing.
+
 4.1.0 (2014-12-27)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,16 @@ import os
 from setuptools import setup, find_packages
 
 def read(*rnames):
-    return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
+    with open(os.path.join(os.path.dirname(__file__), *rnames)) as f:
+        return f.read()
+
+TESTS_REQUIRE = [
+    'ZODB',
+    'zope.testing',
+    'zope.site',
+    'zope.traversing',
+    'zope.container',
+]
 
 setup(name = 'zope.intid',
       version='4.2.0.dev0',
@@ -60,14 +69,10 @@ setup(name = 'zope.intid',
       package_dir = {'': 'src'},
       namespace_packages=['zope'],
       extras_require = dict(
-        test=['zope.testing',
-              'zope.site',
-              'zope.traversing',
-              'zope.container',]),
+        test=TESTS_REQUIRE),
       install_requires = [
         'persistent',
         'BTrees',
-        'ZODB',
         'setuptools',
         'zope.lifecycleevent>=3.5.2',
         'zope.component',
@@ -77,12 +82,7 @@ setup(name = 'zope.intid',
         'zope.location>=3.5.4',
         'zope.security',
         ],
-      tests_require = [
-        'zope.testing',
-        'zope.site',
-        'zope.traversing',
-        'zope.container',
-        ],
+      tests_require = TESTS_REQUIRE,
       test_suite = 'zope.intid.tests.test_suite',
       include_package_data = True,
       zip_safe = False,

--- a/src/zope/intid/tests.py
+++ b/src/zope/intid/tests.py
@@ -178,7 +178,7 @@ class TestIntIds(ReferenceSetupMixin, unittest.TestCase):
         self.assertEqual(maxint, uid)
         # Make an explicit tuple here to avoid implicit type casts
         # by the btree code
-        self.failUnless(maxint in tuple(u.refs.keys()))
+        self.assertIn(maxint, tuple(u.refs.keys()))
 
         # _v_nextid is now set to None, since the last id generated was
         # maxint.
@@ -188,7 +188,7 @@ class TestIntIds(ReferenceSetupMixin, unittest.TestCase):
         conn.add(obj)
         u._randrange = random.randrange
         uid = u.register(obj)
-        self.failUnless(uid < maxint)
+        self.assertLess(uid, maxint)
 
     def test_len_items(self):
         u = self.createIntIds()


### PR DESCRIPTION
Also slightly simplify .travis.yml and enable caching, and fix the two deprecated usages of `failUnless` in the unittest.