### PR TITLE
Raise subclasses of KeyError

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+source = src

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
     - 3.4
     - 3.5
     - pypy
-    - pypy3
+    - pypy3.3-5.2-alpha1
 install:
     - pip install -U pip setuptools # need updated pip for caching
     - pip install .[test]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ Changes
 
 - Drop support for Python 2.6.
 
+- Add support for PyPy3 5.2.
+
 - Stop depending on ZODB for anything except testing.
 
 4.1.0 (2014-12-27)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ Changes
   testing or when persisting intids or sharing them among processes
   for later or concurrent use.
 
+- Propagate ``POSKeyError`` from ``queryId`` instead of returning the
+  default object. This exception indicates a corrupt database, not a
+  missing object. The ``queryObject`` function already behaved this way.
+
 - Add support for Python 3.5.
 
 - Drop support for Python 2.6.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changes
 4.2.0 (unreleased)
 ------------------
 
+- Raise more informative KeyError subclasses from the utility when intids
+  or objects cannot be found. This distinguishes them from errors
+  raised by normal dictionaries or BTrees, and is useful in unit
+  testing or when persisting intids or sharing them among processes
+  for later or concurrent use.
+
 - Add support for Python 3.5.
 
 - Drop support for Python 2.6.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/src/zope/intid/__init__.py
+++ b/src/zope/intid/__init__.py
@@ -73,6 +73,10 @@ class IntIds(Persistent):
         try:
             return self.refs[id]()
         except KeyError:
+            # In theory, if the ZODB and/or our self.ids BTree is
+            # corrupted, this could raise
+            # ZODB.POSException.POSKeyError. We used to propagate that
+            # but now we transform it.
             raise ObjectMissingError(id)
 
     def queryObject(self, id, default=None):
@@ -90,7 +94,7 @@ class IntIds(Persistent):
         try:
             return self.ids[key]
         except KeyError:
-            # In theory, if the ZODB and our self.ids BTree is
+            # In theory, if the ZODB and/or our self.ids BTree is
             # corrupted, this could raise
             # ZODB.POSException.POSKeyError, which we should probably
             # let propagate. But since that's a KeyError, we've always

--- a/src/zope/intid/interfaces.py
+++ b/src/zope/intid/interfaces.py
@@ -2,6 +2,23 @@
 """
 from zope.interface import Interface, Attribute, implementer
 
+class IntIdMissingError(KeyError):
+    """
+    Raised when ``getId`` cannot find an intid.
+    """
+
+class ObjectMissingError(KeyError):
+    """
+    Raised when ``getObject`` cannot find an object.
+    """
+
+class IntIdsCorruptedError(KeyError):
+    """
+    Raised when internal corruption is detected in the utility.
+
+    Users should not need to catch this because this situation should
+    not happen.
+    """
 
 class IIntIdsQuery(Interface):
     "Query for IDs and objects"
@@ -43,7 +60,7 @@ class IIntIdsSet(Interface):
     def unregister(ob):
         """Remove the object from the indexes.
 
-        KeyError is raised if ob is not registered previously.
+        IntIdMissingError is raised if ob is not registered previously.
         """
 
 class IIntIdsManage(Interface):

--- a/tox.ini
+++ b/tox.ini
@@ -4,19 +4,6 @@ envlist =
 
 [testenv]
 commands =
-    python setup.py -q test -q
-# without explicit deps, setup.py test will download a bunch of eggs into $PWD
-# (and it seems I can't use zope.dottedname[testing] here, so forget DRY)
+    python -m zope.intid.tests
 deps =
-    ZODB
-    zope.component
-    zope.container
-    zope.event
-    zope.interface
-    zope.keyreference
-    zope.lifecycleevent
-    zope.location
-    zope.security
-    zope.site
-    zope.testing
-    zope.traversing
+    .[test]


### PR DESCRIPTION
We've found it very useful to be able to distinguish the errors that come from an intid utility from generic dictionary/BTree errors. The main proposed errors are:

```python
class IntIdMissingError(KeyError):
        """
        Raised by the utility when ``getId`` fails.
        """

class ObjectMissingError(KeyError):
        """
        Raised by the utility when ``getObject`` fails.
        """
```

We currently handle this transformation in our own subclass, but it'd be nice if `zope.intid` did it in the first place.

I don't really see any concerns with `getId`, it was already transforming error messages.

`getObject` and `unregister` could theoretically have been raising POSKeyError before and this commit is transforming those. I'm not sure if that's a problem or not.  I could catch that error and specifically let it propagate if so (but then I'd either need to add ZODB as a dependency back, negating #3, or do a soft import.)
