### PR TITLE
Explicitly list the 'trusty' dist to always have access to new PyPy on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,17 @@
 language: python
 sudo: false
+# In July 2017, the default dist is changing slowly to
+# trusty (Ubuntu 14.04) from precise (Ubuntu 12.04). trusty
+# has newer pypy versions that aren't available on precise,
+# so for the time being we force that dist.
+dist: trusty
 python:
     - 2.7
     - 3.4
     - 3.5
     - 3.6
-    - pypy-5.6.0
-    - pypy3.3-5.5-alpha
+    - pypy # 5.8 in July 2017
+    - pypy3.5-5.8.0 # plain pypy3 is missing the activate script
 install:
     - pip install -U pip setuptools # need updated pip for caching
     - pip install -U coverage coveralls


### PR DESCRIPTION
This gets us pypy2 5.8 and pypy3.5.

If we don't specify the dist, we "randomly" waffle back and forth between precise and trusty, meaning we have to specify python versions that are available for both. We can still get pypy3.5, but the newest pypy2 we have access to on both places is pypy-5.6.0 (and just specifying plain 'pypy' is really old on precise last time I checked).

I also like that this lets us avoid having to hardcode a version for 'pypy' (though that's still necessary for PyPy3).

Good idea? Or a long-term maintenance headache?